### PR TITLE
about_self bug fix

### DIFF
--- a/koans/about_self.rb
+++ b/koans/about_self.rb
@@ -118,7 +118,7 @@ class AboutSelf < EdgeCase::Koan
 
   def test_methods_defined_in_Class_class_is_available_to_all_classes
     # All classes are subclasses of Class and inherit methods of Class
-    assert_match __, Person.loud_name
+    assert_match __, Person.new.loud_name
   end
 
 end


### PR DESCRIPTION
Is there a bug in the last test for about_self? Shouldn't it be Person.new.name ? Otherwise it seems to be impossible to pass. The AboutSelf class is namespaced within a dynamically name UniqueRun class. As the classname changes each request, it effectively becomes impossible to pass.
